### PR TITLE
Features/door repurpose

### DIFF
--- a/src/app/src/features/Config/assets/SettingsMenu.ts
+++ b/src/app/src/features/Config/assets/SettingsMenu.ts
@@ -1428,6 +1428,17 @@ export const SettingsMenu: SettingsMenuSection[] = [
                     { type: 'eeprom', eID: '$484' },
                     { type: 'eeprom', eID: '$486' },
                     { type: 'eeprom', eID: '$666' },
+                    {
+                        label: 'Repurpose Door as Pause',
+                        key: 'workspace.repurposeDoorAsPause',
+                        type: 'boolean',
+                        defaultValue: false,
+                        description:
+                            'When enabled, Door status will be displayed as "Pause" instead of "Door". Useful for woodworking CNCs that don\'t use an enclosure door.',
+                        hidden: () => {
+                            return !controller.portOpen;
+                        },
+                    },
                 ],
             },
         ],

--- a/src/app/src/features/MachineStatus/MachineStatus.tsx
+++ b/src/app/src/features/MachineStatus/MachineStatus.tsx
@@ -24,6 +24,7 @@
 import { connect } from 'react-redux';
 import cx from 'classnames';
 import get from 'lodash/get';
+import store from 'app/store';
 import controller from '../../lib/controller';
 import AlarmDescriptionIcon from './AlarmDescriptionIcon';
 import UnlockButton from './UnlockButton';
@@ -46,6 +47,7 @@ interface MachineStatusProps {
     alarmCode: ALARM_CODE;
     activeState: GRBL_ACTIVE_STATES_T;
     isConnected: boolean;
+    doorToPause: boolean;
 }
 
 interface Message {
@@ -61,6 +63,7 @@ const MachineStatus: React.FC<MachineStatusProps> = ({
     activeState,
     alarmCode,
     isConnected,
+    doorToPause,
 }) => {
     const unlock = (): void => {
         if (activeState === GRBL_ACTIVE_STATE_ALARM) {
@@ -98,7 +101,7 @@ const MachineStatus: React.FC<MachineStatusProps> = ({
             Alarm: 'Alarm',
             Disconnected: 'Disconnected',
             Tool: 'Tool Change',
-            Door: 'Door',
+            Door: doorToPause ? 'Pause' : 'Door',
         };
 
         return (
@@ -184,19 +187,21 @@ const MachineStatus: React.FC<MachineStatusProps> = ({
     );
 };
 
-export default connect((store) => {
-    const $22 = get(store, 'controller.settings.settings.$22', '0');
-    const alarmCode = get(store, 'controller.state.status.alarmCode', 0);
+export default connect((reduxStore) => {
+    const $22 = get(reduxStore, 'controller.settings.settings.$22', '0');
+    const alarmCode = get(reduxStore, 'controller.state.status.alarmCode', 0);
     const activeState = get(
-        store,
+        reduxStore,
         'controller.state.status.activeState',
         GRBL_ACTIVE_STATE_IDLE,
     );
-    const isConnected = get(store, 'connection.isConnected', false);
+    const isConnected = get(reduxStore, 'connection.isConnected', false);
+    const doorToPause = store.get('workspace.repurposeDoorAsPause', false);
     return {
         $22,
         alarmCode,
         activeState,
         isConnected,
+        doorToPause,
     };
 })(MachineStatus);

--- a/src/app/src/features/MachineStatus/MachineStatus.tsx
+++ b/src/app/src/features/MachineStatus/MachineStatus.tsx
@@ -101,7 +101,7 @@ const MachineStatus: React.FC<MachineStatusProps> = ({
             Alarm: 'Alarm',
             Disconnected: 'Disconnected',
             Tool: 'Tool Change',
-            Door: doorToPause ? 'Pause' : 'Door',
+            Door: doorToPause ? 'Hold' : 'Door',
         };
 
         return (

--- a/src/server/controllers/Grbl/GrblController.js
+++ b/src/server/controllers/Grbl/GrblController.js
@@ -56,7 +56,6 @@ import {
 import GrblRunner from './GrblRunner';
 import {
     GRBL,
-    GRBL_ACTIVE_STATE_RUN,
     GRBL_ACTIVE_STATE_HOME,
     GRBL_ACTIVE_STATE_ALARM,
     GRBL_ACTIVE_STATE_IDLE,
@@ -1605,12 +1604,7 @@ class GrblController {
 
                 const wcs = _.get(this.state, 'parserstate.modal.wcs', 'G54');
                 if (force) {
-                    let activeState;
-
-                    activeState = _.get(this.state, 'status.activeState', '');
-                    if (activeState === GRBL_ACTIVE_STATE_RUN) {
-                        this.write('!'); // hold
-                    }
+                    this.write('!'); // hold
 
                     await delay(700); // delay 700ms
                     this.write('\x18'); // ^x

--- a/src/server/controllers/Grblhal/GrblHalController.js
+++ b/src/server/controllers/Grblhal/GrblHalController.js
@@ -55,7 +55,6 @@ import {
 import GrblHalRunner from './GrblHalRunner';
 import {
     GRBLHAL,
-    GRBL_ACTIVE_STATE_RUN,
     GRBLHAL_REALTIME_COMMANDS,
     GRBL_HAL_ALARMS,
     GRBL_HAL_ERRORS,
@@ -1708,12 +1707,7 @@ class GrblHalController {
 
                 const wcs = _.get(this.state, 'parserstate.modal.wcs', 'G54');
                 if (force) {
-                    let activeState;
-
-                    activeState = _.get(this.state, 'status.activeState', '');
-                    if (activeState === GRBL_ACTIVE_STATE_RUN) {
-                        this.write('!'); // hold
-                    }
+                    this.write('!'); // hold
 
                     await delay(700); // delay 700ms
                     this.write('\x18'); // ^x


### PR DESCRIPTION
### Enhancements
- **Add option to "Repurpose Door as Pause"**  
  - Allows users to configure the Door input to act as a Pause command.  
  - Requires **grblHAL build `20250731`** or later.  
  - For details, see the [grblHAL changelog](https://github.com/grblHAL/core/blob/master/changelog.md).  

### Fixes
- **Resolved loud/violent sound when clicking Stop**  
  - Removed the previous logic that attempted to issue a pause before stop, which was not functioning correctly.  
  - Stop now executes smoothly without unnecessary noise.